### PR TITLE
[CI] Add github CI workflow.

### DIFF
--- a/.github/workflows/ubuntu-1804-clang.yml
+++ b/.github/workflows/ubuntu-1804-clang.yml
@@ -1,0 +1,29 @@
+name: "Ubuntu 18.04 + clang"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CMAKE_BUILD_TYPE: Debug
+  CC: clang
+  CXX: clang++
+
+jobs:
+
+  configure_build_test:
+    name: "Install, configure, build and test"
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install GTK
+      run: sudo apt-get install libgtk-3-dev
+    - name: Configure
+      run: CC=${{env.CC}} CXX=${{env.CXX}} cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE:STRING=${{env.CMAKE_BUILD_TYPE}}
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.CMAKE_BUILD_TYPE}}
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{env.CMAKE_BUILD_TYPE}}

--- a/.github/workflows/ubuntu-1804-gcc.yml
+++ b/.github/workflows/ubuntu-1804-gcc.yml
@@ -1,0 +1,29 @@
+name: "Ubuntu 18.04 + gcc"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CMAKE_BUILD_TYPE: Debug
+  CC: gcc
+  CXX: g++
+
+jobs:
+
+  configure_build_test:
+    name: "Install, configure, build and test"
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install GTK
+      run: sudo apt-get install libgtk-3-dev
+    - name: Configure
+      run: CC=${{env.CC}} CXX=${{env.CXX}} cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE:STRING=${{env.CMAKE_BUILD_TYPE}}
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.CMAKE_BUILD_TYPE}}
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{env.CMAKE_BUILD_TYPE}}

--- a/.github/workflows/ubuntu-2004-clang.yml
+++ b/.github/workflows/ubuntu-2004-clang.yml
@@ -1,0 +1,29 @@
+name: "Ubuntu 20.04 + clang"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CMAKE_BUILD_TYPE: Debug
+  CC: clang
+  CXX: clang++
+
+jobs:
+
+  configure_build_test:
+    name: "Install, configure, build and test"
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install GTK
+      run: sudo apt-get install libgtk-3-dev
+    - name: Configure
+      run: CC=${{env.CC}} CXX=${{env.CXX}} cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE:STRING=${{env.CMAKE_BUILD_TYPE}}
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.CMAKE_BUILD_TYPE}}
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{env.CMAKE_BUILD_TYPE}}

--- a/.github/workflows/ubuntu-2004-gcc.yml
+++ b/.github/workflows/ubuntu-2004-gcc.yml
@@ -1,0 +1,29 @@
+name: "Ubuntu 20.04 + gcc"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CMAKE_BUILD_TYPE: Debug
+  CC: gcc
+  CXX: g++
+
+jobs:
+
+  configure_build_test:
+    name: "Install, configure, build and test"
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install GTK
+      run: sudo apt-get install libgtk-3-dev
+    - name: Configure
+      run: CC=${{env.CC}} CXX=${{env.CXX}} cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE:STRING=${{env.CMAKE_BUILD_TYPE}}
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.CMAKE_BUILD_TYPE}}
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{env.CMAKE_BUILD_TYPE}}

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,25 @@
 
   This file is part of Tarmac Trace Utilities
 
+
+|CIUbuntu2004gcc| |CIUbuntu2004clang| |CIUbuntu1804gcc| |CIUbuntu1804clang|
+
+.. |CIUbuntu2004gcc| image:: https://github.com/Arnaud-de-Grandmaison-ARM/tarmac-trace-utilities/actions/workflows/ubuntu-2004-gcc.yml/badge.svg
+   :alt: Last build status on Ubuntu 20.04 with gcc
+   :target: https://github.com/Arnaud-de-Grandmaison-ARM/tarmac-trace-utilities/actions/workflows/ubuntu-2004-gcc.yml
+
+.. |CIUbuntu2004clang| image:: https://github.com/Arnaud-de-Grandmaison-ARM/tarmac-trace-utilities/actions/workflows/ubuntu-2004-clang.yml/badge.svg
+   :alt: Last build status on Ubuntu 20.04 with clang
+   :target: https://github.com/Arnaud-de-Grandmaison-ARM/tarmac-trace-utilities/actions/workflows/ubuntu-2004-clang.yml
+
+.. |CIUbuntu1804gcc| image:: https://github.com/Arnaud-de-Grandmaison-ARM/tarmac-trace-utilities/actions/workflows/ubuntu-1804-gcc.yml/badge.svg
+   :alt: Last build status on Ubuntu 18.04 with gcc
+   :target: https://github.com/Arnaud-de-Grandmaison-ARM/tarmac-trace-utilities/actions/workflows/ubuntu-1804-gcc.yml
+
+.. |CIUbuntu1804clang| image:: https://github.com/Arnaud-de-Grandmaison-ARM/tarmac-trace-utilities/actions/workflows/ubuntu-1804-clang.yml/badge.svg
+   :alt: Last build status on Ubuntu 18.04 with clang
+   :target: https://github.com/Arnaud-de-Grandmaison-ARM/tarmac-trace-utilities/actions/workflows/ubuntu-1804-clang.yml
+
 Tarmac Trace Utilities
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This commit sets up 4 worflows, to configure, build and test
tarmac-trace-utilities on Ubuntu 18.04, Ubuntu 20.04 with gcc and clang.

The current status of the CI is shown at the top of the README.rst.