### PR TITLE
Initial support for Tarmac generated by Cortex-M4 RTL.

### DIFF
--- a/tests/parsertest.ref
+++ b/tests/parsertest.ref
@@ -199,6 +199,12 @@ Parse warning: unsupported system operation 'AT'
 * RegisterEvent time=123 reg=q0 offset=0 bytes=3f:f6:a0:9e:66:7f:3b:cd
 --- Tarmac line: 124 ns R Q0 3ff428a2 f98d728b -------- --------
 * RegisterEvent time=124 reg=q0 offset=8 bytes=3f:f4:28:a2:f9:8d:72:8b
+--- Tarmac line:       3041 cyc IT (00022a7c:00000006) 00022a7c     48f6 T16 LDR      r0,[pc,#984]  ; [0x22e58]
+* InstructionEvent time=3041 executed=true pc=22a7c iset=Thumb width=16 instruction=48f6 disassembly="LDR      r0,[pc,#984]  ; [0x22e58]"
+--- Tarmac line:       3039 cyc MNW4___D 2002fa00 efbeefbe
+* MemoryEvent time=3039 read=false known=true addr=2002fa00 size=4 contents=beefbeef
+--- Tarmac line:       3037 cyc MNR4O__I 00022ae4 f7ffffcb
+* TextOnlyEvent time=3037 type="MNR4O__I" text="MNR4O__I 00022ae4 f7ffffcb"
 --- Tarmac line:     1234567 cs E dummy header line to reset timestamp for next two lines
 * TextOnlyEvent time=1234567 type="E" text="dummy header line to reset timestamp for next two lines"
 --- Tarmac line:                     LD 000000007ff80fe0 ........ 44444444 ........ 2222..11    S:007ff80fe0    nGnRnE OSH

--- a/tests/parsertest.txt
+++ b/tests/parsertest.txt
@@ -157,6 +157,17 @@ Tarmac Text Rev 3t
 124 ns R Q0 3ff428a2 f98d728b -------- --------
 
 # ----------------------------------------------------------------------
+
+# Trace lines seen in the output of a Cortex-M4 RTL simulator. Note
+# that the data-bus memory access lines are given in memory order.
+# Instruction fetch lines will be ignored completely (emitted as
+# text-only events).
+
+      3041 cyc IT (00022a7c:00000006) 00022a7c     48f6 T16 LDR      r0,[pc,#984]  ; [0x22e58]
+      3039 cyc MNW4___D 2002fa00 efbeefbe
+      3037 cyc MNR4O__I 00022ae4 f7ffffcb
+
+# ----------------------------------------------------------------------
 # Manually written tests
 
 # Test LD and ST records (showing a 16-byte region of memory with
@@ -193,4 +204,3 @@ R SP 0123456789abcdef
                     R MSP_S 00000000
                     R XPSR f9000000
                     BR (00000000) A
-


### PR DESCRIPTION
This flavour of Tarmac is approximately in the Fast Models style
(IT/IS instruction records, contiguous rather than diagrammatic memory
transfers), but with some awkward differences that aren't clearly
signalled: the CPU mode field is missing from instruction records, and
the data in memory transfers is given in memory order rather than
logical order.

As far as I can tell, these changes manage to support this format
without either breaking the existing test suite or requiring an
up-front mode setting for the Tarmac parser. But it's precarious: the
clues from which I deduce which syntax and semantics to expect don't
really have much to do with the syntax and semantics _differences_, so
it's all a bit more 'recognise the fingerprint of a particular
implementation' than I'd like.

However, it does work, and this change also adds some Cortex-M4 lines
to the parser test suite with their expected output. So if we need to
completely rethink things later, we'll be able to make sure the new
approach still works.