### PR TITLE
Support for us floating point timestamps generated by Incisive

### DIFF
--- a/tests/parsertest-implicit-thumb.ref
+++ b/tests/parsertest-implicit-thumb.ref
@@ -1,2 +1,34 @@
 --- Tarmac line: 354ns IT 00000350 490d        LDR      r1,[pc,#52]  ; [0x388]
 * InstructionEvent time=354 effect=executed pc=350 iset=Thumb width=16 instruction=490d disassembly="LDR      r1,[pc,#52]  ; [0x388]"
+--- Tarmac line:          10.356000us R CONTROL 00000000
+--- Tarmac line:          10.356000us R PRIMASK 00000000
+--- Tarmac line:          10.356000us R PSR f1000003
+* RegisterEvent time=10356000 reg=psr offset=0 bytes=f1:00:00:03
+--- Tarmac line:          10.356000us E HRESETn 0
+* ExceptionEvent time=10356000
+--- Tarmac line:          10.356000us E LOCKUP 0
+* ExceptionEvent time=10356000
+--- Tarmac line:          10.356000us E HALTED 0
+* ExceptionEvent time=10356000
+--- Tarmac line:          10.356000us E INT_READY 0
+* ExceptionEvent time=10356000
+--- Tarmac line:          10.356000us E ATOMIC 1
+* ExceptionEvent time=10356000
+--- Tarmac line:        1166.141000us E HRESETn 1
+* ExceptionEvent time=1166141000
+--- Tarmac line:        1166.177000us MR4_D 00000000 00204800
+* MemoryEvent time=1166177000 read=true known=true addr=0 size=4 contents=204800
+--- Tarmac line:        1166.177000us R MSP 00204800
+* RegisterEvent time=1166177000 reg=r13 offset=0 bytes=00:20:48:00
+--- Tarmac line:        1166.187000us MR4_D 00000004 0000010b
+* MemoryEvent time=1166187000 read=true known=true addr=4 size=4 contents=10b
+--- Tarmac line:        1166.196000us R PSR f1000000
+* RegisterEvent time=1166196000 reg=psr offset=0 bytes=f1:00:00:00
+--- Tarmac line:        1166.196000us E ATOMIC 0
+* ExceptionEvent time=1166196000
+--- Tarmac line:        1166.205000us MR2_I 0000010a b5100000
+* MemoryEvent time=1166205000 read=true known=true addr=10a size=2 contents=b5100000
+--- Tarmac line:        1166.214000us MR4_I 0000010c ffdaf7ff
+* MemoryEvent time=1166214000 read=true known=true addr=10c size=4 contents=ffdaf7ff
+--- Tarmac line:        1166.214000us IT 0000010a b510        PUSH     {r4,lr}
+* InstructionEvent time=1166214000 effect=executed pc=10a iset=Thumb width=16 instruction=b510 disassembly="PUSH     {r4,lr}"

--- a/tests/parsertest-implicit-thumb.txt
+++ b/tests/parsertest-implicit-thumb.txt
@@ -11,3 +11,26 @@
 
 354ns IT 00000350 490d        LDR      r1,[pc,#52]  ; [0x388]
 
+# ----------------------------------------------------------------------
+# Trace lines as output by Cadence Incisive for a Cortex M0+
+# This trace format uses us-level timestamps as floating point numbers.
+# CORTEXM0PLUS TARMAC 00000001
+# hw_top.u_tarmac
+         10.356000us R CONTROL 00000000
+         10.356000us R PRIMASK 00000000
+         10.356000us R PSR f1000003
+         10.356000us E HRESETn 0
+         10.356000us E LOCKUP 0
+         10.356000us E HALTED 0
+         10.356000us E INT_READY 0
+         10.356000us E ATOMIC 1
+       1166.141000us E HRESETn 1
+       1166.177000us MR4_D 00000000 00204800
+       1166.177000us R MSP 00204800
+       1166.187000us MR4_D 00000004 0000010b
+       1166.196000us R PSR f1000000
+       1166.196000us E ATOMIC 0
+       1166.205000us MR2_I 0000010a b5100000
+       1166.214000us MR4_I 0000010c ffdaf7ff
+       1166.214000us IT 0000010a b510        PUSH     {r4,lr}
+


### PR DESCRIPTION
Hey!
We were doing some simulations of a Cortex M0+@108MHz in Cadence Incisive and noticed that the produced tarmac-file couldn't be parsed by the trace-utilities. 
The trace-file contains µs-level timestamp as floating point literals. I just ham-fisted a solution where I convert the floating point timestamps to integers. 


The tarmac-files from incisive looks like this: 
```tarmac
       1166.141000us E HRESETn 1
       1166.177000us MR4_D 00000000 00204800
       1166.177000us R MSP 00204800
       1166.187000us MR4_D 00000004 0000010b
       1166.196000us R PSR f1000000
       1166.196000us E ATOMIC 0
       1166.205000us MR2_I 0000010a b5100000
       1166.214000us MR4_I 0000010c ffdaf7ff
       1166.214000us IT 0000010a b510        PUSH     {r4,lr}
       1166.223000us MW4_D 002047f8 ffffffff
       1166.232000us MW4_D 002047fc ffffffff
       1166.232000us R MSP 002047f8
       1166.250000us IT 0000010c f7ffffda    BL       {pc} - 0x48  ; 0xc4
```