### PR TITLE
[Image] Add support for segments.

### DIFF
--- a/include/libtarmac/elf.hh
+++ b/include/libtarmac/elf.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Arm Limited. All rights reserved.
+ * Copyright 2016-2021,2025 Arm Limited. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,10 @@ static constexpr unsigned STT_NOTYPE = 0;
 static constexpr unsigned STT_OBJECT = 1;
 static constexpr unsigned STT_FUNC = 2;
 
+static constexpr unsigned PF_X = 1;
+static constexpr unsigned PF_W = 2;
+static constexpr unsigned PF_R = 4;
+
 /*
  * These structures don't reflect the precise ELF layout; that's dealt
  * with at load time (including normalising out endianness). As a
@@ -59,6 +63,12 @@ struct ElfSectionHeader {
     uint64_t entries() const;
 };
 
+struct ElfProgramHeader {
+    uint32_t p_type, p_flags;
+    uint64_t p_offset, p_vaddr, p_paddr;
+    uint64_t p_filesz, p_memsz, p_align;
+};
+
 struct ElfSymbol {
     uint32_t st_name;
     uint8_t st_bind, st_type; // physically, both stored in st_info
@@ -73,6 +83,8 @@ class ElfFile {
     virtual bool is_big_endian() const = 0;
     virtual unsigned nsections() const = 0;
     virtual bool section_header(unsigned index, ElfSectionHeader &) const = 0;
+    virtual unsigned nsegments() const = 0;
+    virtual bool program_header(unsigned index, ElfProgramHeader &) const = 0;
     virtual bool symbol(const ElfSectionHeader &shdr, unsigned symbolindex,
                         ElfSymbol &) const = 0;
     virtual std::string strtab_string(const ElfSectionHeader &shdr,

--- a/include/libtarmac/image.hh
+++ b/include/libtarmac/image.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Arm Limited. All rights reserved.
+ * Copyright 2016-2021,2025 Arm Limited. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,24 @@ struct Symbol {
     friend class Image;
 };
 
+struct Segment {
+    Addr addr;
+    size_t size;
+    bool executable;
+    bool writable;
+    bool readable;
+
+    // Get a friendly kind name for the segment kind.
+    const char *getKindName() const;
+
+    Segment(Addr addr, size_t size, bool readable, bool writable,
+            bool executable)
+        : addr(addr), size(size), writable(writable), executable(executable),
+          readable(readable)
+    {
+    }
+};
+
 class Image {
     std::unique_ptr<ElfFile> elf_file;
     const std::string image_filename;
@@ -63,6 +81,7 @@ class Image {
     std::forward_list<Symbol> symbols;
     std::map<Addr, std::vector<const Symbol *>> addrtab;
     std::map<std::string, std::vector<const Symbol *>> symtab;
+    mutable std::vector<Segment> segments;
 
     void add_symbol(const Symbol &sym);
     void load_headers();
@@ -94,6 +113,8 @@ class Image {
                 res.insert(res.end(), it.second.begin(), it.second.end());
         return res;
     }
+
+    const std::vector<Segment> &get_segments() const;
 
     Image(const std::string &image_filename);
     ~Image();

--- a/include/libtarmac/image.hh
+++ b/include/libtarmac/image.hh
@@ -81,7 +81,6 @@ class Image {
     std::forward_list<Symbol> symbols;
     std::map<Addr, std::vector<const Symbol *>> addrtab;
     std::map<std::string, std::vector<const Symbol *>> symtab;
-    mutable std::vector<Segment> segments;
 
     void add_symbol(const Symbol &sym);
     void load_headers();
@@ -114,7 +113,7 @@ class Image {
         return res;
     }
 
-    const std::vector<Segment> &get_segments() const;
+    std::vector<Segment> get_segments(bool use_paddr = false) const;
 
     Image(const std::string &image_filename);
     ~Image();

--- a/lib/image.cpp
+++ b/lib/image.cpp
@@ -215,20 +215,18 @@ const Symbol *Image::find_symbol(const string &name, int index) const
     return nullptr;
 }
 
-const vector<Segment> &Image::get_segments() const
+std::vector<Segment> Image::get_segments(bool use_paddr) const
 {
-    // Lazy initialization of segments.
-    if (segments.empty()) {
-        // Find .shstrtab.
-        for (unsigned idx = 0; idx < elf_file->nsegments(); idx++) {
-            ElfProgramHeader phdr;
-            if (!elf_file->program_header(idx, phdr))
-                continue;
+    std::vector<Segment> segments;
+    for (unsigned idx = 0; idx < elf_file->nsegments(); idx++) {
+        ElfProgramHeader phdr;
+        if (!elf_file->program_header(idx, phdr))
+            continue;
 
-            Segment seg(phdr.p_vaddr, phdr.p_memsz, phdr.p_flags & PF_R,
-                        phdr.p_flags & PF_W, phdr.p_flags & PF_X);
-            segments.push_back(seg);
-        }
+        Segment seg(use_paddr ? phdr.p_paddr : phdr.p_vaddr, phdr.p_memsz,
+                    phdr.p_flags & PF_R, phdr.p_flags & PF_W,
+                    phdr.p_flags & PF_X);
+        segments.push_back(seg);
     }
 
     return segments;

--- a/lib/image.cpp
+++ b/lib/image.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Arm Limited. All rights reserved.
+ * Copyright 2016-2021,2025 Arm Limited. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,6 +213,25 @@ const Symbol *Image::find_symbol(const string &name, int index) const
         } catch (std::out_of_range e) {
         }
     return nullptr;
+}
+
+const vector<Segment> &Image::get_segments() const
+{
+    // Lazy initialization of segments.
+    if (segments.empty()) {
+        // Find .shstrtab.
+        for (unsigned idx = 0; idx < elf_file->nsegments(); idx++) {
+            ElfProgramHeader phdr;
+            if (!elf_file->program_header(idx, phdr))
+                continue;
+
+            Segment seg(phdr.p_vaddr, phdr.p_memsz, phdr.p_flags & PF_R,
+                        phdr.p_flags & PF_W, phdr.p_flags & PF_X);
+            segments.push_back(seg);
+        }
+    }
+
+    return segments;
 }
 
 Image::Image(const string &image_filename) : image_filename(image_filename)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,6 +98,11 @@ add_test(NAME imagetest-find-symbol-by-address
       --match stdout "Symbol at address 0x803c: 'quicksort \\[0x8038, 0x80c8\\) \\(144 bytes\\)"
       ${CMAKE_BINARY_DIR}/imagetest --symbol-addr 0x803C ${CMAKE_CURRENT_SOURCE_DIR}/quicksort.elf
   )
+add_test(NAME imagetest-list-segments
+  COMMAND ${test_driver_cmd}
+      --compare reffile:${CMAKE_CURRENT_SOURCE_DIR}/imagetest-segments.ref stdout
+      ${CMAKE_BINARY_DIR}/imagetest --list-segments ${CMAKE_CURRENT_SOURCE_DIR}/quicksort.elf
+  )
 
 # Tests of tarmac-callinfo, using the sample trace file
 # quicksort.tarmac, made from quicksort.elf. These three tests all ask

--- a/tests/imagetest-segments.ref
+++ b/tests/imagetest-segments.ref
@@ -1,0 +1,1 @@
+Segment at 0x8000 size:292 R:1 W:1 X:1

--- a/tools/imagetest.cpp
+++ b/tools/imagetest.cpp
@@ -39,7 +39,8 @@ int main(int argc, char *argv[])
     enum Action {
         DEBUG_DUMP,
         FIND_SYMBOL_BY_ADDR,
-        FIND_SYMBOL_BY_NAME
+        FIND_SYMBOL_BY_NAME,
+        LIST_SEGMENTS,
     } action = DEBUG_DUMP;
     Addr symbol_addr;
     string symbol_name;
@@ -60,6 +61,8 @@ int main(int argc, char *argv[])
                   action = FIND_SYMBOL_BY_NAME;
                   symbol_name = arg;
               });
+    ap.optnoval({"--list-segments"}, "list memory segments from the image file",
+                [&]() { action = LIST_SEGMENTS; });
     ap.positional("image", "ELF image file to examine",
                   [&](const std::string &arg) { image_filename = arg; });
     ap.parse();
@@ -92,5 +95,14 @@ int main(int argc, char *argv[])
             cout << "No symbol found with name '" << symbol_name << "'\n";
             return EXIT_FAILURE;
         }
+    case LIST_SEGMENTS:
+        for (const Segment &seg : image.get_segments()) {
+            cout << "Segment at 0x" << std::hex << seg.addr;
+            cout << " size:" << std::dec << seg.size;
+            cout << " R:" << seg.readable;
+            cout << " W:" << seg.writable;
+            cout << " X:" << seg.executable << "\n";
+        }
+        return EXIT_SUCCESS;
     }
 }


### PR DESCRIPTION
This allows downstream analysis tools based on tarmac-trace-utilities to have a one-stop shop when checking for example the memory accesses.