### PR TITLE
[TarmacUtility] Refactor Image loading and checking.

### DIFF
--- a/include/libtarmac/tarmacutil.hh
+++ b/include/libtarmac/tarmacutil.hh
@@ -84,17 +84,16 @@ class TarmacUtilityBase {
 
     void updateIndexIfNeeded(const TracePair &trace) const;
 
-    // Try to load the specified ELF image, if any. This has the side
-    // effect of checking its endiannness, and using that to either
-    // set the trace endianness, or complain if an explicitly
-    // specified trace endianness doesn't match it.
-    std::shared_ptr<Image> load_image();
-
   private:
     // Subclass-dependent functionality.
     virtual bool does_indexing() { return true; };
     virtual void postProcessOptions() = 0;
     virtual void setupIndex() const = 0;
+
+    // Load the specified ELF image, if any, and check its endianness, then use
+    // that to either set the trace endianness, or complain if an explicitly
+    // specified trace endianness doesn't match it.
+    void load_image();
 };
 
 /*


### PR DESCRIPTION
With the previous commits adding functionality to access segments info from ELF images, this patch essentially makes the image available to TarmacUtility users --- instead of throwing it after some checks.

The Image is now loaded and checked (if an image filename was provided) before postProcessOptions is invoked. This is a change, but certainly a desirable one as this allows postProcessOptions from the derived classes to use the image.

An additional benefit of this refactoring: the endianness consistency checking is now done for TarmacUtilityMT. It was previously missing from TarmacUtilityMT::postProcessOptions.

I am not convinced by the use of a shared_ptr for the Image so have moved to unique_ptr instead --- this means the TarmacUtility is now the owner of the Image.

Last, I have also refactored TarmacUtilityBase::load_image() to improve its readability, and made it a private method as it's not needed outside of the TarmacUtility base class really.